### PR TITLE
Fix filename in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The suite includes AI-powered self-improvement capabilities in both the download
 
 2. For uploader analysis, run with the `--analyze` or `-a` flag:
    ```
-   python uploader_editing.py --analyze
+   python uploader.py --analyze
    ```
 
 3. For downloader, the self-improvement happens automatically during normal operation


### PR DESCRIPTION
This PR fixes a small discrepancy in the README file:

- Changed `python uploader_editing.py --analyze` to `python uploader.py --analyze`

The correct filename is `uploader.py` as shown in the repository.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author